### PR TITLE
Fixed compilation on windows

### DIFF
--- a/pyreaper/creaper.pyx
+++ b/pyreaper/creaper.pyx
@@ -17,6 +17,8 @@ from libc.stdint cimport int16_t, int32_t
 
 from reaper cimport reaper as _reaper
 
+ctypedef int32_t * int32_t_ptr
+
 cdef class Track:
     cdef _reaper.Track * ptr
 
@@ -181,7 +183,7 @@ def reaper_internal(np.ndarray[np.int16_t, ndim=1, mode="c"] x, fs,
     cdef np.ndarray[np.float32_t, ndim= 1, mode = "c"] pm_times \
         = np.zeros(pN, dtype=np.float32)
     et.GetTrackTimes(pm_track.ptr, & pm_times[0])
-    et.GetTrackVoicedFlags(pm_track.ptr, & pm[0])
+    et.GetTrackVoicedFlags(pm_track.ptr, reinterpret_cast[int32_t_ptr](& pm[0]))
 
     # Get f0 and correlations
     f0_track = Track()

--- a/pyreaper/creaper.pyx
+++ b/pyreaper/creaper.pyx
@@ -17,8 +17,6 @@ from libc.stdint cimport int16_t, int32_t
 
 from reaper cimport reaper as _reaper
 
-ctypedef int32_t * int32_t_ptr
-
 cdef class Track:
     cdef _reaper.Track * ptr
 
@@ -111,7 +109,7 @@ cdef class EpochTracker:
         return True
 
     cdef GetTrackVoicedFlags(self, _reaper.Track * track,
-                             int32_t * voiced_flags):
+                             np.ndarray[np.int32_t, ndim = 1, mode = "c"] voiced_flags):
         cdef int32_t i
         for i in range(0, track.num_frames()):
             voiced_flags[i] = 1 if track.v(i) else 0
@@ -183,7 +181,7 @@ def reaper_internal(np.ndarray[np.int16_t, ndim=1, mode="c"] x, fs,
     cdef np.ndarray[np.float32_t, ndim= 1, mode = "c"] pm_times \
         = np.zeros(pN, dtype=np.float32)
     et.GetTrackTimes(pm_track.ptr, & pm_times[0])
-    et.GetTrackVoicedFlags(pm_track.ptr, reinterpret_cast[int32_t_ptr](& pm[0]))
+    et.GetTrackVoicedFlags(pm_track.ptr, pm)
 
     # Get f0 and correlations
     f0_track = Track()


### PR DESCRIPTION
I have fixed the compiler error preventing the installation on Windows. MSVC refused to cast the pointers, but both pointers should point to typedef'ed int32_t on all platforms so reinterpret_cast should not be a problem here.
This also fixes #6.