### PR TITLE
add build dependencies to fix install from source

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[build-system]
+requires = [
+    "wheel",
+    "setuptools",
+    "packaging",
+    "cython >= 0.21.0",
+    "numpy >= 1.8.0",
+]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
<details>
  <summary><code>pip install pyreaper</code> fails to install</summary>
<pre>
pip install pyreaper
Collecting pyreaper
  Using cached pyreaper-0.0.8.tar.gz (124 kB)
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [6 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/tmp/pip-install-s03_fbrw/pyreaper_473cbdcdb56d4bc3b46dfa8bce38e114/setup.py", line 8, in <module>
          import numpy as np
      ModuleNotFoundError: No module named 'numpy'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
</pre>
</details>


I'tried to install from source but it seems like build dependencies (numpy, Cython) are not configured correctly

<details>
  <summary><code>pip install git+https://github.com/r9y9/pyreaper</code></summary>
<pre>

Collecting git+https://github.com/r9y9/pyreaper
  Cloning https://github.com/r9y9/pyreaper to /tmp/pip-req-build-gtap3quc
  Running command git clone --filter=blob:none --quiet https://github.com/r9y9/pyreaper /tmp/pip-req-build-gtap3quc
  Resolved https://github.com/r9y9/pyreaper to commit f0f09a0735edac92a54095c6752ddbd7b8a450c2
  Running command git submodule update --init --recursive -q
  Preparing metadata (setup.py) ... error                                                                     
  error: subprocess-exited-with-error
                                                       
  × python setup.py egg_info did not run successfully.                                                        
  │ exit code: 1                                       
  ╰─> [6 lines of output]                                                                                     
      Traceback (most recent call last):           
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>                                                                                                                                                                 
        File "/tmp/pip-req-build-gtap3quc/setup.py", line 8, in <module>
          import numpy as np                                                                                                                                                                                                 
      ModuleNotFoundError: No module named 'numpy'                                                                                                                                                                           
      [end of output]                                                                                         
                                                                                                              
  note: This error originates from a subprocess, and is likely not a problem with pip.                
error: metadata-generation-failed                                                                             
                                                                                                              
× Encountered error while generating package metadata.                                                        
╰─> See above for output.                                                                                     
                                                                                                              
note: This is an issue with the package mentioned above, not pip.                                                                                                                                                            
hint: See above for details.                     
</pre>
</details>

This PR fixes that, I tested installation in isolated virtualenv and it installs correctly:

<details>
  <summary><code>pip install git+https://github.com/tandav/pyreaper</code></summary>
<pre>
pip install git+https://github.com/tandav/pyreaper
Collecting git+https://github.com/tandav/pyreaper                                                             
  Cloning https://github.com/tandav/pyreaper to /tmp/pip-req-build-5va0xf3f
  Running command git clone --filter=blob:none --quiet https://github.com/tandav/pyreaper /tmp/pip-req-build-5va0xf3f
  Resolved https://github.com/tandav/pyreaper to commit 1d9cd22b324d4e05bde917c86f5e29c5cf6572d5
  Running command git submodule update --init --recursive -q
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Collecting numpy>=1.8.0
  Using cached numpy-1.23.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (17.1 MB)
Building wheels for collected packages: pyreaper
  Building wheel for pyreaper (pyproject.toml) ... done
  Created wheel for pyreaper: filename=pyreaper-0.0.9.dev0-cp310-cp310-linux_x86_64.whl size=614301 sha256=0aeb4a5b9f6e46bc8d46a86497386aa56ff0d5be8fc39fc3f1aef22e7cfa66be
  Stored in directory: /tmp/pip-ephem-wheel-cache-8ugsflvx/wheels/b0/2d/9b/45bf5cc06c19cc079084b01ee402d3677aa809f826ef03f90b
Successfully built pyreaper
Installing collected packages: numpy, pyreaper
Successfully installed numpy-1.23.4 pyreaper-0.0.9.dev0 
python -c 'import pyreaper' # works
</pre>
</details>



