### PR TITLE
Add github actions with automatic publishing to pypi

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - 'v*'
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python_version: ['3.8', '3.9', '3.10', '3.11']
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python_version }}
+
+      - name: install dependencies
+        run: |
+          git submodule update --init --recursive
+          pip install .
+          pip install -r .requirements-dev.txt
+
+      - name: test
+        run: pytest
+
+
+  build-and-publish-to-pypi:
+    runs-on: ubuntu-latest
+    if: "startsWith(github.ref, 'refs/tags')"
+    needs: test
+    steps:
+      - uses: actions/checkout@master
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          git submodule update --init --recursive
+          python -m pip install --upgrade setuptools build twine
+
+      - name: Build a source tarball and wheel
+        run: python -m build .
+
+      - name:
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: python -m twine upload dist/*

--- a/.requirements-dev.txt
+++ b/.requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest
+scipy


### PR DESCRIPTION
- Hi, it looks like [pypi package](https://pypi.org/project/pyreaper/) is outdated for this repo
- In order to install latest version now I have to install it from github source with `pip install git+https://github.com/r9y9/pyreaper`
- It would be nice to update the pypi package

This PR adds simple github actions config which:
- runs tests for every push and pull request
- if git tag is pushed - it will build python package and upload it to pypi

In order to make it work you should:
1. add your `PYPI_API_TOKEN` variable in the settings/secrets and variables/Actions
2. push current version  tag `v0.0.9-dev`. Tag should have `v` prefix and the rest is verson from [this line](https://github.com/r9y9/pyreaper/blob/02b1462dd1bb3b3455d1ce910e195179ee79eb63/setup.py#L61)